### PR TITLE
isr, irq, swap: optimisation and fixes (#96)

### DIFF
--- a/arch/dspic/core/cpu_idle.c
+++ b/arch/dspic/core/cpu_idle.c
@@ -11,19 +11,23 @@
 #ifndef CONFIG_ARCH_HAS_CUSTOM_CPU_IDLE
 void arch_cpu_idle(void)
 {
-	__builtin_disable_interrupts();
+	/* Mask all interrupts using DISI */
+	__asm__ volatile("DISICTL #7\n\t");
 	Idle();
-	__builtin_enable_interrupts();
+	/* Unmask interrupts (clear DISI) */
+	__asm__ volatile("DISICTL #0\n\t");
 }
 #endif
 
 #ifndef CONFIG_ARCH_HAS_CUSTOM_CPU_ATOMIC_IDLE
 void arch_cpu_atomic_idle(unsigned int key)
 {
-	__builtin_disable_interrupts();
+	/* Mask all interrupts using DISI */
+	__asm__ volatile("DISICTL #7\n\t");
 	Idle();
 	arch_irq_unlock(key);
-	__builtin_enable_interrupts();
+	/* Unmask interrupts (clear DISI) */
+	__asm__ volatile("DISICTL #0\n\t");
 }
 #endif
 

--- a/arch/dspic/core/isr_wrapper.S
+++ b/arch/dspic/core/isr_wrapper.S
@@ -35,14 +35,15 @@ __COMMONInterrupt:
 
     call	w1
     mov.l [--w15], w0
-    call	_arch_dspic_irq_clear
+    lsr.l   w0,#3,w1
+    add.l   #IF_OFFSET,w1       ; Will not carry out, so sets SR.C = 0
+    bsw.bC  [w1], w0            ; Instruction ignores w0[31:3] bits for .b size
 
     /* Check and perform context switch
      */
     sub.l [w8],#1,w0
     mov.l w0,[w8]
     mov.l [--w15], w8
-    cp.l w0,#0
     bra	nz,.L2
     mov.sl #__kernel + ___kernel_t_ready_q_OFFSET,w1
     mov.l [w1],w1
@@ -87,24 +88,8 @@ __COMMONInterrupt:
     2:
     mov.l [--w15], w1
     mov.l [--w15], w2
-    nop
     retfie
 
 .L2:
     ulnk
     retfie
-
-
-GTEXT(arch_dspic_irq_clear)
-SECTION_FUNC(TEXT, arch_dspic_irq_clear)
-	lnk	#0
-	lsr.l	w0,#5,w1
-	sl.l	w1,#2,w1
-	add.l	#IF_OFFSET,w1
-	and.l	w0,#(0x1f&0x7F),w2
-	movs.l	#0x1,w0
-	sl.l	w0,w2,w0
-	com.l	w0,w0
-	and.l	w0,[w1],[w1]
-	ulnk	
-	return

--- a/arch/dspic/core/swap.S
+++ b/arch/dspic/core/swap.S
@@ -40,7 +40,7 @@ SECTION_FUNC(TEXT, arch_swap)
     mov.l w2, [w1 + __thread_t_arch_cpu_level_OFFSET]
 
     /*move -EAGAIN to the member (2s compliment of 11)*/
-    mov.l #0xfffffff5, w2
+    movs.l #0xfff5, w2
     mov.l w2, [w1 + __thread_t_arch_swap_return_value_OFFSET]
     mov.l #1, w2
     mov.l w2, [w1 + __thread_t_arch_swapped_from_thread_OFFSET]
@@ -75,8 +75,8 @@ SECTION_FUNC(TEXT, arch_swap)
     mov.l [w1 + __thread_t_arch_cpu_level_OFFSET], w1
     cp.l w1, #0x0
 
-    bra z, 2f
-    bset.b 0x71, #0x7
+    bra nz, 2f
+    DISICTL w1
     2:
     mov.l [--w15], w2
     mov.l [--w15], w1

--- a/arch/dspic/core/thread.c
+++ b/arch/dspic/core/thread.c
@@ -58,8 +58,8 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack, char *sta
 	thread->callee_saved.stack = (uint32_t)(void *)init_frame + (sizeof(struct arch_esf));
 	thread->callee_saved.frame = (uint32_t)thread->callee_saved.stack;
 	thread->callee_saved.splim = (uint32_t)(thread->stack_info.start + thread->stack_info.size);
-	/*Set the initial key for irq unlock*/
-	thread->arch.cpu_level = 1;
+	/*Set the initial cpu level to context 0*/
+	thread->arch.cpu_level = 0;
 }
 
 int arch_coprocessors_disable(struct k_thread *thread)

--- a/arch/dspic/include/kernel_arch_swap_macro.S
+++ b/arch/dspic/include/kernel_arch_swap_macro.S
@@ -133,16 +133,6 @@
     mov.l [w2], [w1++]
     mov.l #CORCON, w2
     mov.l [w2], [w1++]
-    mov.l #MODCON, w2
-    mov.l [w2], [w1++]
-    mov.l #XMODSRT, w2
-    mov.l [w2], [w1++]
-    mov.l #XMODEND, w2
-    mov.l [w2], [w1++]
-    mov.l #YMODSRT, w2
-    mov.l [w2], [w1++]
-    mov.l #YMODEND, w2
-    mov.l [w2], [w1++]
     mov.l #XBREV, w2
     mov.l [w2], [w1++]
 
@@ -200,21 +190,9 @@
     mov.l [w1++], [w2]
     mov.l #CORCON, w2
     mov.l [w1++], [w2]
-    mov.l #MODCON, w2
-    mov.l [w1++], [w2]
-    mov.l #XMODSRT, w2
-    mov.l [w1++], [w2]
-    mov.l #XMODEND, w2
-    mov.l [w1++], [w2]
-    mov.l #YMODSRT, w2
-    mov.l [w1++], [w2]
-    mov.l #YMODEND, w2
-    mov.l [w1++], [w2]
     mov.l #XBREV, w2
     mov.l [w1++], [w2]
 
-    clr A
-    clr B
     llac.l [W1++], A
     lac.l [W1++], A
     luac.l [W1++], A

--- a/include/zephyr/arch/dspic/arch.h
+++ b/include/zephyr/arch/dspic/arch.h
@@ -83,22 +83,23 @@ static ALWAYS_INLINE void z_dspic_irq_priority_set(unsigned int irq, unsigned in
 
 static ALWAYS_INLINE void arch_irq_unlock(unsigned int key)
 {
-	if (key != 0U) {
-		__builtin_enable_interrupts();
+	if (key == 0U) {
+		/* Unmask interrupts (clear DISI) */
+		__asm__ volatile("DISICTL %0\n\t" : : "r"(key) :);
 	}
 }
 
 static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 {
-	return key;
+	return (key == 0);
 }
 
 static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 {
 	volatile unsigned int key;
 
-	key = INTCON1bits.GIE;
-	__builtin_disable_interrupts();
+	/* Mask all interrupts using DISI */
+	__asm__ volatile("DISICTL #7, %0\n\t" : "=r"(key) : :);
 	return key;
 }
 

--- a/include/zephyr/arch/dspic/thread.h
+++ b/include/zephyr/arch/dspic/thread.h
@@ -65,11 +65,6 @@ struct _callee_saved {
 
 	uint32_t Rcount;  /* repeat loop counter register */
 	uint32_t Corcon;  /* core mode control register */
-	uint32_t modcon;  /* Modulo addressing control register */
-	uint32_t xmodsrt; /* X AGU modulo addressing start register */
-	uint32_t xmodend; /* X AGU modulo addressing end register */
-	uint32_t ymodsrt; /* Y AGU modulo addressing start register */
-	uint32_t ymodend; /* Y AGU modulo addressing end register */
 	uint32_t Xbrev;   /*X AGU reversal addressing control register */
 
 	uint32_t AccL; /* Lower 32 bits of accumulator A */

--- a/soc/microchip/dspic33/dspic33a/power.c
+++ b/soc/microchip/dspic33/dspic33a/power.c
@@ -13,7 +13,8 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 	ARG_UNUSED(substate_id);
 	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
-		__builtin_disable_interrupts();
+		/* Mask all interrupts using DISI */
+		__asm__ volatile("DISICTL #7\n\t");
 		Idle();
 		break;
 	default:
@@ -26,7 +27,8 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	ARG_UNUSED(substate_id);
 	switch (state) {
 	case PM_STATE_SUSPEND_TO_IDLE:
-		__builtin_enable_interrupts();
+		/* Unmask interrupts (clear DISI) */
+		__asm__ volatile("DISICTL #0\n\t");
 		break;
 	default:
 		break;


### PR DESCRIPTION
-Removed arch_dspic_irq_clear() function and made inline -Removed Modulo addressing registers in context switch -Used DISICTL to enable and disable interrupts
-Removed one extra nop instruction in isr_wrapper.S