### PR TITLE
drivers: i2c: mchp_sercom_g1: add multi-address target support

### DIFF
--- a/drivers/i2c/Kconfig.mchp
+++ b/drivers/i2c/Kconfig.mchp
@@ -42,6 +42,16 @@ config I2C_MCHP_TARGET
 	help
 	  This enables target device support for the I2C peripheral.
 
+config I2C_MCHP_TARGET_MULTI_ADDR
+	bool "Multi-address target support for Microchip I2C devices"
+	default n
+	depends on I2C_MCHP_TARGET
+	help
+	  Enable dual-address target mode for Microchip I2C SERCOM devices.
+	  When enabled, the driver can register two target addresses and
+	  route transactions based on the matched address. Both addresses
+	  must be 7-bit when using dual-address mode.
+
 config I2C_TARGET_BUFFER_MODE
 	bool "Target Buffer Mode support for Microchip I2C devices"
 	default n

--- a/drivers/i2c/i2c_mchp_sercom_g1.c
+++ b/drivers/i2c/i2c_mchp_sercom_g1.c
@@ -35,6 +35,9 @@ LOG_MODULE_REGISTER(i2c_mchp_sercom_g1, CONFIG_I2C_LOG_LEVEL);
 #endif /*CONFIG_I2C_MCHP_TRANSFER_TIMEOUT*/
 #define I2C_MCHP_TARGET_ACK_STATUS_RECEIVED_ACK  0
 #define I2C_MCHP_TARGET_ACK_STATUS_RECEIVED_NACK 1
+#ifdef CONFIG_I2C_MCHP_TARGET_MULTI_ADDR
+#define I2C_MCHP_TARGET_CFG_SLOTS               2
+#endif /* CONFIG_I2C_MCHP_TARGET_MULTI_ADDR */
 
 /* Timeout values for WAIT_FOR macro*/
 #define TIMEOUT_VALUE_US 1000
@@ -97,9 +100,23 @@ struct i2c_mchp_dev_data {
 	void *user_data;
 #endif /*CONFIG_I2C_CALLBACK*/
 #ifdef CONFIG_I2C_TARGET
-	struct i2c_target_config target_config;
-	struct i2c_target_callbacks target_callbacks;
+#ifdef CONFIG_I2C_MCHP_TARGET_MULTI_ADDR
+	/* Registered target configs (hardware supports up to two addresses). */
+	struct i2c_target_config *target_cfgs[I2C_MCHP_TARGET_CFG_SLOTS];
+	uint8_t target_cfg_count;
+#else
+	/* Single target configuration (legacy behavior). */
+	struct i2c_target_config *target_cfg;
+#endif
+
+	/* Pointer to the config currently being served on the bus. */
+	struct i2c_target_config *active_target_cfg;
+
+	/* Data buffer for RX/TX operations in target mode. */
 	uint8_t rx_tx_data;
+
+	/* First byte read after an address match. */
+	bool firstReadAfterAddrMatch;
 #endif /*CONFIG_I2C_TARGET*/
 #ifdef CONFIG_I2C_MCHP_DMA_DRIVEN
 	const struct i2c_mchp_dev_config *cfg;
@@ -112,15 +129,22 @@ struct i2c_mchp_dev_data {
 	uint32_t tx_pos;
 	uint32_t tx_len;
 #endif /*CONFIG_I2C_TARGET_BUFFER_MODE */
-
-	/* First byte read after an address match. */
-	bool firstReadAfterAddrMatch;
 };
 
 #ifdef CONFIG_I2C_MCHP_DMA_DRIVEN
 static int i2c_dma_write_config(const struct device *dev);
 static int i2c_dma_read_config(const struct device *dev);
 #endif /*CONFIG_I2C_MCHP_DMA_DRIVEN*/
+
+#ifdef CONFIG_I2C_TARGET
+#ifdef CONFIG_I2C_MCHP_TARGET_MULTI_ADDR
+/* Forward declarations for multi-address target support */
+static struct i2c_target_config *i2c_mchp_find_target_cfg(struct i2c_mchp_dev_data *data,
+							  uint16_t addr);
+static uint16_t i2c_mchp_get_matched_addr(const struct device *dev);
+#endif /* CONFIG_I2C_MCHP_TARGET_MULTI_ADDR */
+static int i2c_set_apply_bitrate(const struct device *dev, uint32_t config);
+#endif /* CONFIG_I2C_TARGET */
 
 static void i2c_swrst(const struct device *dev)
 {
@@ -753,27 +777,64 @@ void i2c_target_set_command(const struct device *dev, enum i2c_mchp_target_cmd c
 static void i2c_target_address_match(const struct device *dev, struct i2c_mchp_dev_data *data,
 				     uint16_t target_status)
 {
-	const struct i2c_target_callbacks *target_cb = &data->target_callbacks;
+#ifdef CONFIG_I2C_MCHP_TARGET_MULTI_ADDR
+	uint16_t matched_addr = i2c_mchp_get_matched_addr(dev);
+#endif
+	const struct i2c_target_callbacks *target_cb;
+
+#ifdef CONFIG_I2C_MCHP_TARGET_MULTI_ADDR
+	data->active_target_cfg = i2c_mchp_find_target_cfg(data, matched_addr);
+	if (data->active_target_cfg == NULL) {
+		LOG_ERR("No target configuration for address 0x%02x", matched_addr);
+		i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_SEND_NACK);
+		return;
+	}
+#else
+	data->active_target_cfg = data->target_cfg;
+	if (data->active_target_cfg == NULL) {
+		LOG_ERR("No target configuration registered");
+		i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_SEND_NACK);
+		return;
+	}
+#endif
+
+	target_cb = data->active_target_cfg->callbacks;
+	if (target_cb == NULL) {
+		LOG_ERR("Target callbacks not set");
+		i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_SEND_NACK);
+		return;
+	}
 
 	i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_SEND_ACK);
 	data->firstReadAfterAddrMatch = true;
 
 	if ((target_status & SERCOM_I2CS_STATUS_DIR_Msk) == SERCOM_I2CS_STATUS_DIR_Msk) {
-
-		/* Load the first byte for host read */
-		target_cb->read_requested(&data->target_config, &data->rx_tx_data);
+		/* Host read (target transmits) */
+		if (target_cb->read_requested != NULL) {
+			target_cb->read_requested(data->active_target_cfg, &data->rx_tx_data);
+		}
 	} else {
-
-		/* Host writing */
-		target_cb->write_requested(&data->target_config);
+		/* Host write (target receives) */
+		if (target_cb->write_requested != NULL) {
+			target_cb->write_requested(data->active_target_cfg);
+		}
 	}
 }
 
 static void i2c_target_data_ready(const struct device *dev, struct i2c_mchp_dev_data *data,
 				  uint16_t target_status)
 {
-	const struct i2c_target_callbacks *target_cb = &data->target_callbacks;
-	int retval;
+	const struct i2c_mchp_dev_config *cfg = dev->config;
+	struct i2c_target_config *active_cfg = data->active_target_cfg;
+	const struct i2c_target_callbacks *target_cb =
+		(active_cfg != NULL) ? active_cfg->callbacks : NULL;
+	int retval = I2C_MCHP_SUCCESS;
+
+	if ((active_cfg == NULL) || (target_cb == NULL)) {
+		LOG_ERR("DRDY with no active target configuration");
+		i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_SEND_NACK);
+		return;
+	}
 
 	if (((target_status & SERCOM_I2CS_STATUS_DIR_Msk) == SERCOM_I2CS_STATUS_DIR_Msk)) {
 		if ((data->firstReadAfterAddrMatch == true) ||
@@ -785,8 +846,10 @@ static void i2c_target_data_ready(const struct device *dev, struct i2c_mchp_dev_
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
 			if (data->tx_len == 0U) {
 				/* Request a new buffer of data to send */
-				retval = target_cb->buf_read_requested(
-					&data->target_config, &data->tx_buf_ptr, &data->tx_len);
+				if (target_cb->buf_read_requested != NULL) {
+					retval = target_cb->buf_read_requested(
+						active_cfg, &data->tx_buf_ptr, &data->tx_len);
+				}
 				data->tx_pos = 0;
 				if ((retval < 0) || (data->tx_len == 0U) ||
 				    (data->tx_buf_ptr == NULL)) {
@@ -805,13 +868,20 @@ static void i2c_target_data_ready(const struct device *dev, struct i2c_mchp_dev_
 			i2c_byte_write(dev, data->rx_tx_data);
 
 			/* Load the next byte for host read*/
-			target_cb->read_processed(&data->target_config, &data->rx_tx_data);
+			if (target_cb->read_processed != NULL) {
+				target_cb->read_processed(active_cfg, &data->rx_tx_data);
+			}
 
 #endif /* CONFIG_I2C_TARGET_BUFFER_MODE */
 
 			/* first byte read after address match done*/
 			data->firstReadAfterAddrMatch = false;
-			i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_RECEIVE_ACK_NAK);
+
+			/* Only issue CMD if SMEN disabled; SMEN auto-executes on DATA write */
+			if ((cfg->regs->I2CS.SERCOM_CTRLB & SERCOM_I2CS_CTRLB_SMEN_Msk) == 0) {
+				i2c_target_set_command(dev,
+						       I2C_MCHP_TARGET_COMMAND_RECEIVE_ACK_NAK);
+			}
 
 		} else {
 			i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_WAIT_FOR_START);
@@ -830,7 +900,9 @@ static void i2c_target_data_ready(const struct device *dev, struct i2c_mchp_dev_
 
 #else
 		data->rx_tx_data = i2c_byte_read(dev);
-		retval = target_cb->write_received(&data->target_config, data->rx_tx_data);
+		if (target_cb->write_received != NULL) {
+			retval = target_cb->write_received(active_cfg, data->rx_tx_data);
+		}
 		if (retval != I2C_MCHP_SUCCESS) {
 			i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_SEND_NACK);
 		}
@@ -841,7 +913,9 @@ static void i2c_target_data_ready(const struct device *dev, struct i2c_mchp_dev_
 static void i2c_target_handler(const struct device *dev)
 {
 	struct i2c_mchp_dev_data *data = dev->data;
-	const struct i2c_target_callbacks *target_cb = &data->target_callbacks;
+	struct i2c_target_config *active_cfg = data->active_target_cfg;
+	const struct i2c_target_callbacks *target_cb =
+		(active_cfg != NULL) ? active_cfg->callbacks : NULL;
 	uint8_t int_status = i2c_target_int_flag_get(dev);
 	uint16_t target_status = i2c_target_status_get(dev);
 
@@ -849,14 +923,16 @@ static void i2c_target_handler(const struct device *dev)
 	if ((int_status & SERCOM_I2CS_INTFLAG_ERROR_Msk) == SERCOM_I2CS_INTFLAG_ERROR_Msk) {
 		i2c_target_int_flag_clear(dev, SERCOM_I2CS_INTFLAG_ERROR_Msk);
 		LOG_ERR("Interrupt Error generated");
-		target_cb->stop(&data->target_config);
+		if ((target_cb != NULL) && (target_cb->stop != NULL)) {
+			target_cb->stop(active_cfg);
+		}
+		data->active_target_cfg = NULL;
+		data->firstReadAfterAddrMatch = false;
 	} else {
 
 		/* Handle address match */
 		if ((int_status & SERCOM_I2CS_INTFLAG_AMATCH_Msk) ==
 		    SERCOM_I2CS_INTFLAG_AMATCH_Msk) {
-			i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_SEND_ACK);
-			data->firstReadAfterAddrMatch = true;
 			i2c_target_address_match(dev, data, target_status);
 		}
 
@@ -869,10 +945,12 @@ static void i2c_target_handler(const struct device *dev)
 	/* Handle stop condition interrupt */
 	if ((int_status & SERCOM_I2CS_INTFLAG_PREC_Msk) == SERCOM_I2CS_INTFLAG_PREC_Msk) {
 		i2c_target_int_flag_clear(dev, SERCOM_I2CS_INTFLAG_PREC_Msk);
+		active_cfg = data->active_target_cfg;
+		target_cb = (active_cfg != NULL) ? active_cfg->callbacks : NULL;
 
 #ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-		if ((data->rx_len > 0U) && (target_cb->buf_write_received != NULL)) {
-			target_cb->buf_write_received(&data->target_config, data->rx_buf_internal,
+		if ((data->rx_len > 0U) && (target_cb != NULL) && (target_cb->buf_write_received != NULL)) {
+			target_cb->buf_write_received(active_cfg, data->rx_buf_internal,
 						      data->rx_len);
 		}
 		data->rx_len = 0;
@@ -881,7 +959,11 @@ static void i2c_target_handler(const struct device *dev)
 #endif /*CONFIG_I2C_TARGET_BUFFER_MODE */
 
 		/* Notify that a stop condition was received */
-		target_cb->stop(&data->target_config);
+		if ((target_cb != NULL) && (target_cb->stop != NULL)) {
+			target_cb->stop(active_cfg);
+		}
+		data->active_target_cfg = NULL;
+		data->firstReadAfterAddrMatch = false;
 	}
 
 	i2c_target_status_clear(dev, target_status);
@@ -1134,87 +1216,333 @@ static void i2c_target_int_disable(const struct device *dev, uint8_t target_int)
 	i2c_regs->I2CS.SERCOM_INTENCLR = int_clear;
 }
 
-static void i2c_set_target_addr(const struct device *dev, uint32_t addr)
+#ifdef CONFIG_I2C_MCHP_TARGET_MULTI_ADDR
+static bool i2c_mchp_target_matches_addr(const struct i2c_target_config *cfg, uint16_t addr)
+{
+	uint16_t normalized_addr = addr & 0x3FFU;
+
+	if (cfg == NULL) {
+		return false;
+	}
+
+	return ((cfg->address & 0x3FFU) == normalized_addr);
+}
+
+static struct i2c_target_config *i2c_mchp_find_target_cfg(struct i2c_mchp_dev_data *data,
+							  uint16_t addr)
+{
+	for (int i = 0; i < I2C_MCHP_TARGET_CFG_SLOTS; i++) {
+		if (data->target_cfgs[i] == NULL) {
+			continue;
+		}
+
+		if (i2c_mchp_target_matches_addr(data->target_cfgs[i], addr) == true) {
+			return data->target_cfgs[i];
+		}
+	}
+
+	return NULL;
+}
+
+static uint16_t i2c_mchp_get_matched_addr(const struct device *dev)
 {
 	sercom_registers_t *i2c_regs = ((const struct i2c_mchp_dev_config *)(dev)->config)->regs;
+	uint8_t raw_data = (uint8_t)i2c_regs->I2CS.SERCOM_DATA;
+	uint16_t inferred_addr = (uint16_t)((raw_data >> 1) & 0x3FFU);
 
-	i2c_regs->I2CS.SERCOM_ADDR = (i2c_regs->I2CS.SERCOM_ADDR & ~SERCOM_I2CS_ADDR_ADDR_Msk) |
-				     SERCOM_I2CS_ADDR_ADDR(addr);
+	return inferred_addr;
 }
+
+static void i2c_mchp_apply_target_addrs(const struct device *dev)
+{
+	struct i2c_mchp_dev_data *data = dev->data;
+	sercom_registers_t *i2c_regs = ((const struct i2c_mchp_dev_config *)(dev)->config)->regs;
+	struct i2c_target_config *primary_cfg = data->target_cfgs[0];
+	struct i2c_target_config *secondary_cfg = data->target_cfgs[1];
+	uint32_t addr_reg = 0U;
+	uint32_t amode_val = SERCOM_I2CS_CTRLB_AMODE_MASK_Val;
+
+	if (primary_cfg == NULL) {
+		i2c_regs->I2CS.SERCOM_ADDR &=
+			~(SERCOM_I2CS_ADDR_ADDR_Msk | SERCOM_I2CS_ADDR_ADDRMASK_Msk |
+			  SERCOM_I2CS_ADDR_TENBITEN_Msk);
+		return;
+	}
+
+	addr_reg |= SERCOM_I2CS_ADDR_ADDR(primary_cfg->address & 0x3FFU);
+
+	if ((primary_cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0U) {
+		addr_reg |= SERCOM_I2CS_ADDR_TENBITEN(1);
+	}
+
+	if (secondary_cfg != NULL) {
+		addr_reg |= SERCOM_I2CS_ADDR_ADDRMASK(secondary_cfg->address & 0x3FFU);
+		amode_val = SERCOM_I2CS_CTRLB_AMODE_2_ADDRESSES_Val;
+	} else {
+		addr_reg |= SERCOM_I2CS_ADDR_ADDRMASK(0U);
+		amode_val = SERCOM_I2CS_CTRLB_AMODE_MASK_Val;
+	}
+
+	i2c_regs->I2CS.SERCOM_ADDR =
+		(i2c_regs->I2CS.SERCOM_ADDR &
+		 ~(SERCOM_I2CS_ADDR_ADDR_Msk | SERCOM_I2CS_ADDR_ADDRMASK_Msk |
+		   SERCOM_I2CS_ADDR_TENBITEN_Msk)) |
+		addr_reg;
+
+	i2c_regs->I2CS.SERCOM_CTRLB =
+		(i2c_regs->I2CS.SERCOM_CTRLB & ~SERCOM_I2CS_CTRLB_AMODE_Msk) |
+		SERCOM_I2CS_CTRLB_AMODE(amode_val);
+}
+#else
+static void i2c_mchp_apply_target_addr_single(const struct device *dev,
+					      const struct i2c_target_config *cfg)
+{
+	sercom_registers_t *i2c_regs = ((const struct i2c_mchp_dev_config *)(dev)->config)->regs;
+	uint32_t addr_reg = SERCOM_I2CS_ADDR_ADDR(cfg->address & 0x3FFU);
+
+	if ((cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0U) {
+		addr_reg |= SERCOM_I2CS_ADDR_TENBITEN(1);
+	}
+
+	i2c_regs->I2CS.SERCOM_ADDR =
+		(i2c_regs->I2CS.SERCOM_ADDR &
+		 ~(SERCOM_I2CS_ADDR_ADDR_Msk | SERCOM_I2CS_ADDR_ADDRMASK_Msk |
+		   SERCOM_I2CS_ADDR_TENBITEN_Msk)) |
+		addr_reg;
+
+	i2c_regs->I2CS.SERCOM_CTRLB =
+		(i2c_regs->I2CS.SERCOM_CTRLB & ~SERCOM_I2CS_CTRLB_AMODE_Msk) |
+		SERCOM_I2CS_CTRLB_AMODE(SERCOM_I2CS_CTRLB_AMODE_MASK_Val);
+}
+#endif /* CONFIG_I2C_MCHP_TARGET_MULTI_ADDR */
 
 static int i2c_mchp_target_register(const struct device *dev, struct i2c_target_config *target_cfg)
 {
 	struct i2c_mchp_dev_data *data = dev->data;
+	int slot = -1;
+	int retval = 0;
+	bool ten_bit;
+	uint16_t addr_limit;
 
-	if (data->target_mode == true) {
-		LOG_ERR("Device already registered in target mode.");
-		return -EBUSY;
-	}
 	if ((target_cfg == NULL) || (target_cfg->callbacks == NULL)) {
 		LOG_ERR("Invalid target configuration or missing callbacks");
 		return -EINVAL;
 	}
-	if (target_cfg->address == I2C_INVALID_ADDR) {
-		LOG_ERR("device can't be register in target mode with 0x00 "
-			"address\n");
+
+	ten_bit = ((target_cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0U);
+	addr_limit = ten_bit ? 0x3FFU : 0x7FU;
+
+	if (target_cfg->address == I2C_INVALID_ADDR || target_cfg->address > addr_limit) {
+		LOG_ERR("target address 0x%x is invalid or exceeds %s-bit range",
+			target_cfg->address, ten_bit ? "10" : "7");
 		return -EINVAL;
 	}
 
 	k_mutex_lock(&data->i2c_bus_mutex, K_FOREVER);
-	data->target_config.address = target_cfg->address;
-	data->target_callbacks.write_requested = target_cfg->callbacks->write_requested;
-	data->target_callbacks.write_received = target_cfg->callbacks->write_received;
-	data->target_callbacks.read_requested = target_cfg->callbacks->read_requested;
-	data->target_callbacks.read_processed = target_cfg->callbacks->read_processed;
-	data->target_callbacks.stop = target_cfg->callbacks->stop;
 
-#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-	data->target_callbacks.buf_write_received = target_cfg->callbacks->buf_write_received;
-	data->target_callbacks.buf_read_requested = target_cfg->callbacks->buf_read_requested;
-#endif /*CONFIG_I2C_TARGET_BUFFER_MODE */
+#ifdef CONFIG_I2C_MCHP_TARGET_MULTI_ADDR
+	do {
+		if (data->target_cfg_count >= I2C_MCHP_TARGET_CFG_SLOTS) {
+			retval = -EBUSY;
+			break;
+		}
 
-	i2c_target_enable(dev, false);
-	i2c_target_int_disable(dev, SERCOM_I2CS_INTENSET_Msk);
-	i2c_set_target_mode(dev);
-	i2c_set_target_addr(dev, data->target_config.address);
-	i2c_target_int_enable(dev, SERCOM_I2CS_INTENSET_Msk);
-	data->target_mode = true;
-	i2c_target_runstandby_enable(dev);
-	i2c_target_enable(dev, true);
+		for (int i = 0; i < I2C_MCHP_TARGET_CFG_SLOTS; i++) {
+			if (data->target_cfgs[i] == target_cfg) {
+				retval = -EALREADY;
+				break;
+			}
+
+			if ((slot < 0) && (data->target_cfgs[i] == NULL)) {
+				slot = i;
+			}
+		}
+
+		if (retval != 0) {
+			break;
+		}
+
+		if (slot < 0) {
+			retval = -EBUSY;
+			break;
+		}
+
+		/* Secondary address restrictions: primary must exist and both must be 7-bit */
+		if (slot == 1) {
+			struct i2c_target_config *primary_cfg = data->target_cfgs[0];
+
+			if ((primary_cfg == NULL) ||
+			    ((primary_cfg->flags & I2C_TARGET_FLAGS_ADDR_10_BITS) != 0U) ||
+			    (ten_bit == true)) {
+				retval = -EINVAL;
+				break;
+			}
+		}
+
+		i2c_target_enable(dev, false);
+		if (data->target_mode == false) {
+			/* Switch from controller to target mode */
+			i2c_controller_enable(dev, false);
+			i2c_controller_int_disable(dev, SERCOM_I2CM_INTENSET_Msk);
+			i2c_controller_int_flag_clear(dev, SERCOM_I2CM_INTFLAG_Msk);
+			i2c_controller_status_clear(dev, SERCOM_I2CM_STATUS_Msk);
+
+			i2c_swrst(dev);
+			i2c_set_target_mode(dev);
+			i2c_target_runstandby_enable(dev);
+			i2c_target_int_disable(dev, SERCOM_I2CS_INTENSET_Msk);
+			i2c_target_int_flag_clear(dev, SERCOM_I2CS_INTFLAG_Msk);
+			i2c_target_status_clear(dev, SERCOM_I2CS_STATUS_Msk);
+		}
+
+		data->target_cfgs[slot] = target_cfg;
+		data->target_cfg_count++;
+		data->target_mode = true;
+
+		i2c_mchp_apply_target_addrs(dev);
+
+		i2c_target_enable(dev, true);
+		i2c_target_runstandby_enable(dev);
+		i2c_target_int_enable(dev, SERCOM_I2CS_INTENSET_Msk);
+		i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_WAIT_FOR_START);
+	} while (0);
+#else
+	if (data->target_cfg != NULL) {
+		LOG_ERR("Device already registered in target mode");
+		retval = (data->target_cfg == target_cfg) ? -EALREADY : -EBUSY;
+	}
+
+	if (retval == 0) {
+		i2c_target_enable(dev, false);
+		if (data->target_mode == false) {
+			/* Switch from controller to target mode */
+			i2c_controller_enable(dev, false);
+			i2c_controller_int_disable(dev, SERCOM_I2CM_INTENSET_Msk);
+			i2c_controller_int_flag_clear(dev, SERCOM_I2CM_INTFLAG_Msk);
+			i2c_controller_status_clear(dev, SERCOM_I2CM_STATUS_Msk);
+
+			i2c_swrst(dev);
+			i2c_set_target_mode(dev);
+			i2c_target_runstandby_enable(dev);
+			i2c_target_int_disable(dev, SERCOM_I2CS_INTENSET_Msk);
+			i2c_target_int_flag_clear(dev, SERCOM_I2CS_INTFLAG_Msk);
+			i2c_target_status_clear(dev, SERCOM_I2CS_STATUS_Msk);
+		}
+
+		data->target_cfg = target_cfg;
+		data->target_mode = true;
+		i2c_mchp_apply_target_addr_single(dev, target_cfg);
+
+		i2c_target_enable(dev, true);
+		i2c_target_runstandby_enable(dev);
+		i2c_target_int_enable(dev, SERCOM_I2CS_INTENSET_Msk);
+		i2c_target_set_command(dev, I2C_MCHP_TARGET_COMMAND_WAIT_FOR_START);
+	}
+#endif /* CONFIG_I2C_MCHP_TARGET_MULTI_ADDR */
+
 	k_mutex_unlock(&data->i2c_bus_mutex);
 
-	return I2C_MCHP_SUCCESS;
+	return retval;
 }
 
 static int i2c_mchp_target_unregister(const struct device *dev,
 				      struct i2c_target_config *target_cfg)
 {
 	struct i2c_mchp_dev_data *data = dev->data;
+	int retval = 0;
+	int slot = -1;
 
 	if (target_cfg == NULL) {
 		LOG_ERR("target_cfg is NULL");
 		return -EINVAL;
 	}
-	if (data->target_mode != true) {
-		LOG_ERR("device are not configured as target device\n");
-		return -EBUSY;
-	}
-	if (data->target_config.address != target_cfg->address) {
-		LOG_ERR("Target address mismatch");
-		return -EINVAL;
-	}
 
 	k_mutex_lock(&data->i2c_bus_mutex, K_FOREVER);
-	i2c_target_enable(dev, false);
-	i2c_target_int_disable(dev, SERCOM_I2CS_INTENSET_Msk);
-	i2c_reset_target_addr(dev);
-	data->target_mode = false;
-	data->target_config.address = 0x00;
-	data->target_config.callbacks = NULL;
-	i2c_target_enable(dev, true);
+
+#ifdef CONFIG_I2C_MCHP_TARGET_MULTI_ADDR
+	do {
+		if ((data->target_mode == false) || (data->target_cfg_count == 0U)) {
+			LOG_ERR("device is not configured as target device");
+			retval = -EBUSY;
+			break;
+		}
+
+		for (int i = 0; i < I2C_MCHP_TARGET_CFG_SLOTS; i++) {
+			if (data->target_cfgs[i] == target_cfg) {
+				slot = i;
+				break;
+			}
+		}
+
+		if (slot < 0) {
+			LOG_ERR("Target configuration not found");
+			retval = -EINVAL;
+			break;
+		}
+
+		i2c_target_enable(dev, false);
+
+		data->target_cfgs[slot] = NULL;
+		data->target_cfg_count--;
+
+		if (data->target_cfg_count == 0U) {
+			/* No more targets, disable target mode and restore master mode */
+			data->target_mode = false;
+			i2c_target_int_disable(dev, SERCOM_I2CS_INTENSET_Msk);
+			i2c_reset_target_addr(dev);
+
+			/* Reset SERCOM and reconfigure as master */
+			i2c_swrst(dev);
+			i2c_set_controller_mode(dev);
+			i2c_set_apply_bitrate(dev, I2C_SPEED_SET(data->dev_config));
+			i2c_controller_enable(dev, true);
+			i2c_set_controller_bus_state_idle(dev);
+		} else {
+			/* Compact: if slot 0 is now empty but slot 1 has a config, move it */
+			if ((slot == 0) && (data->target_cfgs[1] != NULL)) {
+				data->target_cfgs[0] = data->target_cfgs[1];
+				data->target_cfgs[1] = NULL;
+			}
+			i2c_mchp_apply_target_addrs(dev);
+			i2c_target_enable(dev, true);
+		}
+	} while (0);
+#else
+	do {
+		if ((data->target_mode == false) || (data->target_cfg == NULL)) {
+			LOG_ERR("device is not configured as target device");
+			retval = -EBUSY;
+			break;
+		}
+
+		if (data->target_cfg != target_cfg) {
+			LOG_ERR("Target address mismatch");
+			retval = -EINVAL;
+			break;
+		}
+
+		i2c_target_enable(dev, false);
+
+		data->target_cfg = NULL;
+		data->active_target_cfg = NULL;
+		data->firstReadAfterAddrMatch = false;
+		data->target_mode = false;
+
+		i2c_target_int_disable(dev, SERCOM_I2CS_INTENSET_Msk);
+		i2c_reset_target_addr(dev);
+
+		/* Reset SERCOM and reconfigure as master */
+		i2c_swrst(dev);
+		i2c_set_controller_mode(dev);
+		i2c_set_apply_bitrate(dev, I2C_SPEED_SET(data->dev_config));
+		i2c_controller_enable(dev, true);
+		i2c_set_controller_bus_state_idle(dev);
+	} while (0);
+#endif /* CONFIG_I2C_MCHP_TARGET_MULTI_ADDR */
+
 	k_mutex_unlock(&data->i2c_bus_mutex);
 
-	return I2C_MCHP_SUCCESS;
+	return retval;
 }
 #endif /*CONFIG_I2C_MCHP_TARGET*/
 
@@ -1809,11 +2137,10 @@ static int i2c_mchp_configure(const struct device *dev, uint32_t config)
 	i2c_controller_enable(dev, false);
 
 	if ((config & I2C_MODE_CONTROLLER) == I2C_MODE_CONTROLLER) {
-
 		i2c_set_controller_mode(dev);
 	}
-	if (I2C_SPEED_GET(config) != I2C_MCHP_SUCCESS) {
 
+	if (I2C_SPEED_GET(config) != I2C_MCHP_SUCCESS) {
 		retval = i2c_set_apply_bitrate(dev, config);
 		if (retval != I2C_MCHP_SUCCESS) {
 			LOG_ERR("Failed to set bitrate: %d", retval);


### PR DESCRIPTION
Add support for registering up to two I2C target addresses on a single SERCOM instance, leveraging the hardware's dual-address capability via the AMODE field.

Changes:
- Replace single target_config/target_callbacks with target_cfgs[2] pointer array to support multiple registered configurations
- Add target_cfg_count and active_target_cfg tracking
- Add helper functions for address matching and configuration lookup
- Update i2c_target_register() for slot-based registration with validation of 7-bit/10-bit address constraints
- Update i2c_target_unregister() with slot compaction when removing the primary address
- Update interrupt handlers to dispatch to the correct configuration based on the matched address

The secondary address uses the ADDRMASK register with AMODE set to 2_ADDRESSES mode. Both addresses must be 7-bit when using dual-address mode per hardware requirements.